### PR TITLE
fix websites in plugin info

### DIFF
--- a/Upload/inc/plugins/transferthread.php
+++ b/Upload/inc/plugins/transferthread.php
@@ -24,9 +24,9 @@ function transferthread_info()
     return array(
         "name"          => "Transfer Thread",
         "description"   => "Adds a new moderation option through which a thread ownership can be transferred to another user.",
-        "website"       => "website TODO",
+        "website"       => "https://github.com/zegkljan/MyBB-Transfer-Thread",
         "author"        => "Jan Žegklitz",
-        "authorsite"    => "zegkljan.net",
+        "authorsite"    => "http://zegkljan.net/",
         "version"       => "0.1",
         "guid"          => "",
         "codename"      => $codename,


### PR DESCRIPTION
Without protocol, the `authorsite` was pointing from 
`https://forum.example.com/admin/index.php?module=config-plugins`
to a relative path 
`https://forum.example.com/admin/zegkljan.net` 

Also, HTTPS doesn't work for https://zegkljan.net/ as it uses a certificate issued to `*.github.com` and `github.com`